### PR TITLE
Fixed issue with tick triggering a cron message every time.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Bot-BasicBot-Pluggable-Module-Crontab
 ==========================================================
 
+Next release
+        - GH-#1 Fix issue with tick triggering every time
+
 0.01    2015-04-26
         - original release;

--- a/lib/Bot/BasicBot/Pluggable/Module/Crontab.pm
+++ b/lib/Bot/BasicBot/Pluggable/Module/Crontab.pm
@@ -23,6 +23,7 @@ use Time::Crontab;
 
 my @crontab;
 my $load_time = 0;
+my $last_run;
 
 #----------------------------------------------------------------------------
 
@@ -39,6 +40,7 @@ sub init {
         $file =~ s/\.pl$/.cron/;
     }
 
+    $last_run = DateTime->now;
     $self->store->set( 'crontab', 'file', $file );
 }
  
@@ -48,6 +50,10 @@ sub help {
  
 sub tick {
     my $self = shift;
+
+    # Shortcut the tick if its still the same minute as last time
+    return if $last_run->minute == DateTime->now->minute;
+    $last_run = DateTime->now;
 
     $self->_load_cron();
 
@@ -65,7 +71,7 @@ sub tick {
         );
     }
 
-    return 60 - DateTime->now->second; # ensure we are running each minute
+    return; # return value is ignored
 }
 
 #############################################################################


### PR DESCRIPTION
Closes #1 

The issue is that tick is triggered every 5 seconds - which means that the bot will send a message every 5 seconds during the minute which is specified in the cron command. This PR fixes this by tracking the last time the loop was run, and triggering if the minute does not match.